### PR TITLE
Add items table to index page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,9 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
-    jest: true
+    jest: true,
+    node: 1
+
   },
   extends: [
     'plugin:react/recommended',
@@ -21,6 +23,7 @@ module.exports = {
   rules: {
     'react/prop-types': 'off',
     'react/jsx-uses-react': 'error',
-    'no-unused-vars': 'off'
+    'no-unused-vars': 'off',
+    quotes: [2, 'single', { avoidEscape: true, allowTemplateLiterals: true }]
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import Welcome from './components/welcome/welcome.js'
+import ItemsIndex from './components/ItemsIndex/ItemsIndex.js'
 
 class App extends Component {
   constructor (props) {
@@ -9,12 +10,23 @@ class App extends Component {
     this.state = {
       isLoaded: props.isLoaded || false,
       text: '',
-      error: null
+      error: null,
+      items: null
     }
   }
 
   componentDidMount () {
+    this.getStoreItems()
     this.getWelcomeString()
+  }
+
+  getStoreItems () {
+    this.apiHandler.getStoreItems().then(json => {
+      this.setState({
+        items: json.items,
+        error: json.error
+      })
+    })
   }
 
   getWelcomeString () {
@@ -28,14 +40,19 @@ class App extends Component {
   }
 
   render () {
-    const { isLoaded, error, text } = this.state
+    const { isLoaded, error, text, items } = this.state
     if (error) {
       return <div data-testid="error-message">{error}</div>
     } else if (!isLoaded) {
       return <div data-testid="loading-message">Loading...</div>
     } else {
       return (
+        <div>
           <Welcome welcomeString={text}/>
+          {this.state.items && (
+            <ItemsIndex items={items}/>
+          )}
+        </div>
       )
     }
   }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -30,4 +30,11 @@ describe('App', () => {
       screen.getByTestId('error-message')
     ).toBeInTheDocument()
   })
+  it('renders an items table', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('items-table')
+    ).toBeInTheDocument()
+  })
 })

--- a/src/apiHandler.js
+++ b/src/apiHandler.js
@@ -1,11 +1,19 @@
-const apiURL = 'https://safe-wave-09726.herokuapp.com/api/v1/welcome'
+const apiURL = 'https://safe-wave-09726.herokuapp.com/api/v1'
 
 class ApiHandler {
   async getWelcomeString () {
-    const response = await fetch(apiURL)
+    const response = await fetch(`${apiURL}/welcome`)
     const text = await response.text()
     const error = await response.error
     return ({ text: text, error: error })
+  }
+
+  async getStoreItems () {
+    const response = await fetch(`${apiURL}/items`)
+    const json = await response.json()
+    const error = await response.error
+    console.log({ items: json, error: error })
+    return ({ items: json, error: error })
   }
 }
 export default ApiHandler

--- a/src/components/ItemsIndex/ItemsIndex.js
+++ b/src/components/ItemsIndex/ItemsIndex.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react'
+
+const ItemsIndex = (props) => {
+  const items = props.items.items
+  return (
+    <div>
+
+    {items
+      ? <table data-testid='items-table'>
+      <thead>
+        <tr>
+          <th data-testid="item-header">Items</th>
+        </tr>
+        <tr>
+          <th data-testid="item-name-header">Item Name</th>
+          <th data-testid="item-sellIn-header">Sell In Date</th>
+          <th data-testid="item-quality-header">Quality</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map(item => (
+          <tr key={item.id}>
+            <td data-testid='item-name'>{item.name}</td>
+            <td data-testid="item-sellIn">{item.sell_in}</td>
+            <td data-testid="item-quality">{item.quality}</td>
+          </tr>
+        ))
+        }
+      </tbody>
+   </table>
+      : <h4 data-testid='no-items-message'>No items available.</h4>
+    }
+    </div>
+  )
+}
+
+export default ItemsIndex

--- a/src/components/ItemsIndex/ItemsIndex.test.js
+++ b/src/components/ItemsIndex/ItemsIndex.test.js
@@ -1,0 +1,128 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import App from '../../App'
+import MockApiHandler from '../../services/__mocks__/mockApiHandler'
+
+describe('ItemsIndex', () => {
+  it('renders a no items message when there are no items available', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome to the Gilded Rose LLC store!', null, { undefined })
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('no-items-message')
+    ).toBeInTheDocument()
+  })
+  it('renders a table with an items header', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome to the Gilded Rose LLC store!', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('item-header')
+    ).toBeInTheDocument()
+  })
+  it('renders a table with an item name header', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome to the Gilded Rose LLC store!', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('item-name-header')
+    ).toBeInTheDocument()
+  })
+  it('renders a table with an item sell in date header', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome to the Gilded Rose LLC store!', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      expect(
+        screen.getByTestId('item-sellIn-header')
+      ).toBeInTheDocument()
+    )
+  })
+  it('renders a table with a quality score header', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome to the Gilded Rose LLC store!', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('item-quality-header')
+    ).toBeInTheDocument()
+  })
+  it('renders data in the item name column', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    const itemNames = screen.queryAllByTestId('item-name')
+    expect(itemNames.length).toEqual(5)
+  })
+  it('renders data in the item sellIn column', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    const itemNames = screen.queryAllByTestId('item-sellIn')
+    expect(itemNames.length).toEqual(5)
+  })
+  it('renders data in the item quality column', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome', null)
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    const itemNames = screen.queryAllByTestId('item-quality')
+    expect(itemNames.length).toEqual(5)
+  })
+  it('renders a table with a single item', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome', null,
+      {
+        items: [
+          { id: 1, name: 'Aged Brie', sellIn: 3, quality: 20 }]
+      })
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('items-table')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Aged Brie')
+    ).toBeInTheDocument()
+  })
+  it('renders a table with multiple items', async () => {
+    const mockApiHandler = new MockApiHandler('Welcome', null,
+      {
+        items: [
+          { id: 1, name: 'Aged Brie', sellIn: 3, quality: 20 },
+          {
+            id: 2,
+            name: 'Foo',
+            sellIn: 25,
+            quality: 2
+          },
+          {
+            id: 3,
+            name: 'Bar',
+            sellIn: 22,
+            quality: 10
+          },
+          {
+            id: 4,
+            name: 'Lorem',
+            sellIn: 2,
+            quality: 5
+          },
+          {
+            id: 5,
+            name: 'Ipsum',
+            sellIn: 4,
+            quality: 16
+          }
+        ]
+      })
+    await render(<App apiHandler={ mockApiHandler } isLoaded={ true }/>)
+    expect(
+      screen.getByTestId('items-table')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Aged Brie')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Foo')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Bar')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Lorem')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Ipsum')
+    ).toBeInTheDocument()
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom'
 import './index.css'
 import App from './App'
 import reportWebVitals from './reportWebVitals'
-import ApiHandler from '.gi/apiHandler'
+import ApiHandler from './apiHandler'
 const apiHandler = new ApiHandler()
 
 ReactDOM.render(

--- a/src/services/__mocks__/mockApiHandler.js
+++ b/src/services/__mocks__/mockApiHandler.js
@@ -1,11 +1,51 @@
+const storeItems = {
+  items:
+[
+  {
+    id: 1,
+    name: 'Aged Brie',
+    sellIn: 3,
+    quality: 20
+  },
+  {
+    id: 2,
+    name: 'Foo',
+    sellIn: 25,
+    quality: 2
+  },
+  {
+    id: 3,
+    name: 'Bar',
+    sellIn: 22,
+    quality: 10
+  },
+  {
+    id: 4,
+    name: 'Lorem',
+    sellIn: 2,
+    quality: 5
+  },
+  {
+    id: 5,
+    name: 'Ipsum',
+    sellIn: 4,
+    quality: 16
+  }
+]
+}
 class MockApiHandler {
-  constructor (text, error) {
+  constructor (text, error, items) {
     this.text = text
     this.error = error
+    this.items = items || storeItems
   }
 
   async getWelcomeString () {
     return ({ text: this.text, error: this.error })
+  }
+
+  async getStoreItems () {
+    return ({ items: this.items, error: this.error })
   }
 }
 export default MockApiHandler


### PR DESCRIPTION
**Summary**

The `add-items-index` branch is adding the feature for the user to be able to go to the Gilded Rose LLC store webpage and view a table of all the items in the store. 

<img width="583" alt="itemsTable" src="https://user-images.githubusercontent.com/43938783/116619168-bca82980-a905-11eb-97ce-fa3bffb05292.png">

**Follow up work**

The next feature will build onto this feature by adding the ability to view the details of an individual item.

**Questions**

- This conditional rendering statement ended up fairly verbose with the HTML. I tried to extract the code into a variable or a method, and I was unable to get it to work. I finally retired to just get it working first. I would love feedback on this. 

<img width="465" alt="itemsIndex" src="https://user-images.githubusercontent.com/43938783/116620715-d185bc80-a907-11eb-9512-e08f33f0c1f7.png">

