### PR TITLE
Convert item sell in attribute to camelCase

### DIFF
--- a/src/components/itemForm/itemForm.js
+++ b/src/components/itemForm/itemForm.js
@@ -5,13 +5,13 @@ const ItemForm = (props) => {
   const { apiHandler }= props
   const history = useHistory()
   const [name, setName] = useState('')
-  const [sell_in, setSellIn] = useState('')
+  const [sellIn, setSellIn] = useState('')
   const [quality, setQuality] = useState('')
 
 
   let formData = {
     name: name,
-    sell_in: sell_in,
+    sellIn: sellIn,
     quality: quality
   }
 
@@ -39,9 +39,9 @@ const ItemForm = (props) => {
         <input
         type="number"
         min="1"
-        name="sell_in"
-        data-testid="sell_in-field"
-        value={sell_in}
+        name="sellIn"
+        data-testid="sellIn-field"
+        value={sellIn}
         onChange={e => setSellIn(e.target.value)}
         required
         />

--- a/src/components/itemForm/itemForm.test.js
+++ b/src/components/itemForm/itemForm.test.js
@@ -25,7 +25,7 @@ describe("ItemForm", () => {
       screen.getByTestId("name-field"),
     ).toBeInTheDocument()
     expect(
-      screen.getByTestId("sell_in-field"),
+      screen.getByTestId("sellIn-field"),
     ).toBeInTheDocument()
     expect(
       screen.getByTestId("quality-field"),

--- a/src/components/itemPage/itemPage.js
+++ b/src/components/itemPage/itemPage.js
@@ -9,7 +9,7 @@ return (
     {data && (
       <>
         <h2 data-testid="item-name">Item: {data.name}</h2>
-        <h3 data-testid="item-sell_in">Sell In: {data.sell_in}</h3>
+        <h3 data-testid="item-sellIn">Sell In: {data.sellIn}</h3>
         <h3 data-testid="item-quality">Quality: {data.quality}</h3>
       </>
     )}

--- a/src/components/itemPage/itemPage.test.js
+++ b/src/components/itemPage/itemPage.test.js
@@ -17,7 +17,7 @@ describe("ItemPage", () => {
       screen.getByTestId("item-name"),
     ).toBeInTheDocument()
     expect(
-      screen.getByTestId("item-sell_in"),
+      screen.getByTestId("item-sellIn"),
     ).toBeInTheDocument()
     expect(
       screen.getByTestId("item-quality"),

--- a/src/components/itemsIndex/itemsIndex.js
+++ b/src/components/itemsIndex/itemsIndex.js
@@ -20,7 +20,7 @@ const ItemsIndex = (props) => {
       {items.map((item) => (
         <tr key={item.id}>
           <td data-testid="item-name"><Link to={`/items/${item.id}`}>{item.name}</Link></td>
-          <td data-testid="item-sellIn">{item.sell_in}</td>
+          <td data-testid="item-sellIn">{item.sellIn}</td>
           <td data-testid="item-quality">{item.quality}</td>
         </tr>
       ))}

--- a/src/services/__mocks__/mockApiHandler.js
+++ b/src/services/__mocks__/mockApiHandler.js
@@ -3,31 +3,31 @@ const storeItems =
   {
     id: 1,
     name: "Aged Brie",
-    sell_in: 3,
+    sellIn: 3,
     quality: 20,
   },
   {
     id: 2,
     name: "Foo",
-    sell_in: 25,
+    sellIn: 25,
     quality: 2,
   },
   {
     id: 3,
     name: "Bar",
-    sell_in: 22,
+    sellIn: 22,
     quality: 10,
   },
   {
     id: 4,
     name: "Lorem",
-    sell_in: 2,
+    sellIin: 2,
     quality: 5,
   },
   {
     id: 5,
     name: "Ipsum",
-    sell_in: 4,
+    sellIn: 4,
     quality: 16,
   }
 ]


### PR DESCRIPTION
## Summary ##

The `change-to-sellIn` branch changes the item "Sell In" attribute from snake_case to camelCase to reflect the rails Gilded Rose API updates. 
          