### PR TITLE
Remove event handler from api handler

### DIFF
--- a/src/apiHandler.js
+++ b/src/apiHandler.js
@@ -33,11 +33,6 @@ class ApiHandler {
     return data
   }
 
-  handleSubmit(event, formData, history){
-    event.preventDefault()
-    this.postNewItem(formData, history)
-  }
-
   async postNewItem(formData, history) {
     const requestOptions = {
       method: 'POST',

--- a/src/components/itemForm/itemForm.js
+++ b/src/components/itemForm/itemForm.js
@@ -15,11 +15,15 @@ const ItemForm = (props) => {
     quality: quality
   }
 
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    apiHandler.postNewItem(formData, history)
+  }
   
   return (
     <form
     data-testid="new-item-form"
-    onSubmit={(event) => {apiHandler.handleSubmit(event, formData, history)}}
+    onSubmit={handleSubmit}
     >
     <br/>
       <label>

--- a/src/components/itemForm/itemForm.test.js
+++ b/src/components/itemForm/itemForm.test.js
@@ -36,13 +36,13 @@ describe("ItemForm", () => {
   })
     test('it submits the form on submit', () => {
       const mockApiHandler = new MockApiHandler("Welcome to the Gilded Rose LLC store!", null)
-      mockApiHandler.handleSubmit = jest.fn().mockImplementation((e) => e.preventDefault())
+      mockApiHandler.postNewItem = jest.fn()
       render(<ItemForm apiHandler={mockApiHandler}/>)
       const submitButton = screen.getByTestId('submit-button')
 
       userEvent.click(submitButton)
 
-      expect(mockApiHandler.handleSubmit).toHaveBeenCalled()
+      expect(mockApiHandler.postNewItem).toHaveBeenCalled()
     })
   })
 

--- a/src/services/__mocks__/mockApiHandler.js
+++ b/src/services/__mocks__/mockApiHandler.js
@@ -57,12 +57,6 @@ class MockApiHandler {
     return item
   }
 
-  handleSubmit(event, formData, history){
-    event.preventDefault()
-    this.postNewItem(formData, history)
-    console.log('submitted')
-  }
-
   postNewItem(formData, history) {
     return (formData, history)
   }


### PR DESCRIPTION
## Summary

The `refactor-event-handler` branch removes the item form eventHandler function out of the API handler.  This will allow the postNewItem function to be tested easier and the API Handler more open to adding new features. 

## Future work
- Setup jest mock library
-  Move history.replace into the ItemForm component
