### PR TITLE
Refactor post fetch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
         "jest": true
     },
     "globals": {
-        "Promise": "off",
+        "Promise": true,
         "process": true
     },
     "extends": [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16.1": "^1.6.4",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "history": "^5.0.0",
     "react": "^17.0.2",
     "react-async": "^10.0.1",
     "react-dom": "^17.0.2",

--- a/src/apiHandler.js
+++ b/src/apiHandler.js
@@ -33,20 +33,13 @@ class ApiHandler {
     return data
   }
 
-  async postNewItem(formData, history) {
+  postNewItem(formData) {
     const requestOptions = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(formData)
   };
-    await fetch(`${this.url}/items`, requestOptions)
-        .then(response => response.json())
-        .then((item) => {
-          history.replace(`/items/${item.id}`)
-        })
-        .catch(error => {
-          return <h3>{error.message}</h3>
-        })
+    return fetch(`${this.url}/items`, requestOptions)
   }
 }
 export default ApiHandler

--- a/src/components/itemForm/itemForm.js
+++ b/src/components/itemForm/itemForm.js
@@ -21,6 +21,9 @@ const ItemForm = (props) => {
       .then((item) => {
         history.replace(`/items/${item.id}`)
       })
+      .catch((error) => {
+        console.error(error.message)
+      })
   }
   
   return (

--- a/src/components/itemForm/itemForm.js
+++ b/src/components/itemForm/itemForm.js
@@ -8,7 +8,6 @@ const ItemForm = (props) => {
   const [sellIn, setSellIn] = useState('')
   const [quality, setQuality] = useState('')
 
-
   let formData = {
     name: name,
     sellIn: sellIn,
@@ -21,9 +20,6 @@ const ItemForm = (props) => {
       .then(response => response.json())
       .then((item) => {
         history.replace(`/items/${item.id}`)
-      })
-      .catch(error => {
-        return <h3>{error.message}</h3>
       })
   }
   

--- a/src/components/itemForm/itemForm.js
+++ b/src/components/itemForm/itemForm.js
@@ -17,7 +17,14 @@ const ItemForm = (props) => {
 
   const handleSubmit = (event) => {
     event.preventDefault()
-    apiHandler.postNewItem(formData, history)
+    apiHandler.postNewItem(formData)
+      .then(response => response.json())
+      .then((item) => {
+        history.replace(`/items/${item.id}`)
+      })
+      .catch(error => {
+        return <h3>{error.message}</h3>
+      })
   }
   
   return (

--- a/src/components/itemForm/itemForm.test.js
+++ b/src/components/itemForm/itemForm.test.js
@@ -36,7 +36,7 @@ describe("ItemForm", () => {
   })
     test('it submits the form on submit', () => {
       const mockApiHandler = new MockApiHandler("Welcome to the Gilded Rose LLC store!", null)
-      mockApiHandler.postNewItem = jest.fn()
+      mockApiHandler.postNewItem = jest.fn().mockReturnValue(Promise.resolve({}))
       render(<ItemForm apiHandler={mockApiHandler}/>)
       const submitButton = screen.getByTestId('submit-button')
 
@@ -45,5 +45,3 @@ describe("ItemForm", () => {
       expect(mockApiHandler.postNewItem).toHaveBeenCalled()
     })
   })
-
-

--- a/src/components/itemForm/itemForm.test.js
+++ b/src/components/itemForm/itemForm.test.js
@@ -7,6 +7,10 @@ import ItemForm from "./itemForm"
 import MockApiHandler from "../../services/__mocks__/mockApiHandler"
 
 describe("ItemForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
   test("renders ItemForm component", () => {
     render(<ItemForm />)
   })
@@ -70,5 +74,27 @@ describe("ItemForm", () => {
       userEvent.click(submitButton)
 
       await waitFor(() => expect(history.location.pathname).toBe(`/items/${item.id}`))
+    })
+
+    test('catches when handleSubmit throws an exception', async () => {
+      const mockApiHandler = new MockApiHandler("Welcome to the Gilded Rose LLC store!", null)
+      const history = createMemoryHistory()
+      const error = new Error("Nope")
+      mockApiHandler.postNewItem = jest.fn(() => Promise.reject(
+        error
+      ))
+
+      window.console.error = jest.fn()
+
+      render(
+        <Router history={history}>
+          <ItemForm apiHandler={mockApiHandler}/>
+        </Router>
+      )
+      const submitButton = screen.getByTestId('submit-button')
+
+      userEvent.click(submitButton)
+
+      await waitFor(() => expect(window.console.error).toHaveBeenLastCalledWith(error.message))
     })
   })

--- a/src/services/__mocks__/mockApiHandler.js
+++ b/src/services/__mocks__/mockApiHandler.js
@@ -57,8 +57,8 @@ class MockApiHandler {
     return item
   }
 
-  postNewItem(formData, history) {
-    return (formData, history)
+  postNewItem(formData) {
+    return formData
   }
 }
 export default MockApiHandler

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,6 +1164,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.7.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -5748,6 +5755,13 @@ history@^4.9.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
+
+history@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
+  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary 
The `refactor-post-fetch` branch relocates the form handleSubmit function from the apiHandler to the Item form. This refactor allows for easier testing and adds more separation of concerns. More test coverage was added to test actions after the API call is made. 

# Future work 
- Add Auth headers

